### PR TITLE
Added timzone to supported locations

### DIFF
--- a/apps/core/lib/core/collection_schedule.ex
+++ b/apps/core/lib/core/collection_schedule.ex
@@ -1,11 +1,10 @@
 defmodule Core.CollectionSchedule do
   use Core.Model
 
-  @fields [:scheduled_date, :utc_offset]
+  @fields [:scheduled_date]
 
   schema "collection_schedules" do
     field :scheduled_date, :date
-    field :utc_offset, :string
     belongs_to :supported_location, SupportedLocation
     belongs_to :collect_type, CollectType
     

--- a/apps/core/lib/core/supported_location.ex
+++ b/apps/core/lib/core/supported_location.ex
@@ -1,13 +1,14 @@
 defmodule Core.SupportedLocation do
   use Core.Model
 
-  @fields [:city, :province_or_state, :country, :country_code] 
+  @fields [:city, :province_or_state, :country, :country_code, :timezone] 
 
   schema "supported_locations" do
     field :city, :string
     field :province_or_state, :string
     field :country, :string
     field :country_code, :string
+    field :timezone, :string
     has_many :collection_schedules, CollectionSchedule
     
     timestamps()

--- a/apps/core/priv/repo/migrations/20170201001909_add_timezone_to_supported_location.exs
+++ b/apps/core/priv/repo/migrations/20170201001909_add_timezone_to_supported_location.exs
@@ -1,0 +1,9 @@
+defmodule Core.Repo.Migrations.AddTimezoneToSupportedLocation do
+  use Ecto.Migration
+
+  def change do
+    alter table(:supported_locations) do
+      add :timezone, :string
+    end
+  end
+end

--- a/apps/core/priv/repo/migrations/20170201003935_remove_utc_offset_from_collection_schedule.exs
+++ b/apps/core/priv/repo/migrations/20170201003935_remove_utc_offset_from_collection_schedule.exs
@@ -1,0 +1,9 @@
+defmodule Core.Repo.Migrations.RemoveUtcOffsetFromCollectionSchedule do
+  use Ecto.Migration
+
+  def change do
+    alter table(:collection_schedules) do
+      remove :utc_offset
+    end
+  end
+end

--- a/apps/core/test/core/collection_schedule_test.exs
+++ b/apps/core/test/core/collection_schedule_test.exs
@@ -1,8 +1,8 @@
 defmodule Core.CollectionScheduleTest do
   use Core.Case
 
-  @valid_attrs %{scheduled_date: "2017-01-01", utc_offset: "UTC-05:00"}
-  @invalid_date %{scheduled_date: "random string", utc_offset: "UTC-05:00"}
+  @valid_attrs %{scheduled_date: "2017-01-01"}
+  @invalid_date %{scheduled_date: "random string"}
   @invalid_attrs %{}
 
   test "changset with valid attributes" do

--- a/apps/core/test/core/supported_location_test.exs
+++ b/apps/core/test/core/supported_location_test.exs
@@ -5,7 +5,8 @@ defmodule Core.SuppotedLocationTest do
     city: "Buenos Aires",
     province_or_state: "Buenos Aires",
     country: "Argentina",
-    country_code: "AR"
+    country_code: "AR",
+    timezone: "America/Argentina/Buenos_Aires"
   }
 
   test "changeset with valid attributes" do

--- a/apps/core/test/support/factory.ex
+++ b/apps/core/test/support/factory.ex
@@ -11,7 +11,6 @@ defmodule Core.Factory do
   def collection_schedule_factory do
     %CollectionSchedule{
       scheduled_date: ~D[2017-01-01],
-      utc_offset: "UTC-5:00",
       collect_type: build(:collect_type),
       supported_location: build(:supported_location)
     }


### PR DESCRIPTION
Since we are dealing with _future_ events each location will store the full name of the its timezone and utc_offset will be removed from collection schedules

- [x] Add timezone and to supported location and enhance tests
- [x] Remove `utc_offset` from collection schedules